### PR TITLE
When adapting, transform input passives to consistent orientation

### DIFF
--- a/lib/adapt/EditOperation.ts
+++ b/lib/adapt/EditOperation.ts
@@ -37,6 +37,13 @@ export interface RemoveChipOp {
   chipId: string
 }
 
+export interface ChangePassiveOrientationOp {
+  type: "change_passive_orientation"
+  chipId: string
+  fromOrientation: "horizontal" | "vertical"
+  toOrientation: "horizontal" | "vertical"
+}
+
 export type EditOperation =
   | AddLabelToPinOp
   | AddPassiveToPinOp
@@ -44,3 +51,4 @@ export type EditOperation =
   | RemoveChipOp
   | AddPinToSideOp
   | RemovePinFromSideOp
+  | ChangePassiveOrientationOp

--- a/lib/adapt/applyEditOperation/applyChangePassiveOrientation.ts
+++ b/lib/adapt/applyEditOperation/applyChangePassiveOrientation.ts
@@ -1,0 +1,65 @@
+import type { CircuitBuilder } from "lib/builder"
+import type { ChangePassiveOrientationOp } from "../EditOperation"
+
+export function applyChangePassiveOrientation(
+  C: CircuitBuilder,
+  op: ChangePassiveOrientationOp,
+): void {
+  const chip = C.chips.find((c) => c.chipId === op.chipId)
+  if (!chip) {
+    throw new Error(`Chip ${op.chipId} not found`)
+  }
+
+  if (!chip.isPassive) {
+    throw new Error(`Chip ${op.chipId} is not a passive component`)
+  }
+
+  // For now, we'll implement a simple rotation by swapping pin configurations
+  // This assumes the passive has exactly 2 pins
+  if (chip.totalPinCount !== 2) {
+    throw new Error(
+      `Passive orientation change only supports 2-pin passives, got ${chip.totalPinCount} pins`,
+    )
+  }
+
+  // Determine current orientation
+  const currentOrientation =
+    chip.leftPinCount > 0 || chip.rightPinCount > 0 ? "horizontal" : "vertical"
+
+  if (currentOrientation === op.toOrientation) {
+    // No change needed
+    return
+  }
+
+  // Transform the passive orientation
+  if (op.toOrientation === "horizontal") {
+    // Convert vertical to horizontal: bottom/top pins -> left/right pins
+    chip.leftPinCount = 1
+    chip.rightPinCount = 1
+    chip.bottomPinCount = 0
+    chip.topPinCount = 0
+
+    // Update pin arrays
+    chip.leftPins = [chip.bottomPins[0] || chip.topPins[0]]
+    chip.rightPins = [chip.topPins[0] || chip.bottomPins[0]]
+    chip.bottomPins = []
+    chip.topPins = []
+  } else {
+    // Convert horizontal to vertical: left/right pins -> bottom/top pins
+    chip.bottomPinCount = 1
+    chip.topPinCount = 1
+    chip.leftPinCount = 0
+    chip.rightPinCount = 0
+
+    // Update pin arrays
+    chip.bottomPins = [chip.leftPins[0] || chip.rightPins[0]]
+    chip.topPins = [chip.rightPins[0] || chip.leftPins[0]]
+    chip.leftPins = []
+    chip.rightPins = []
+  }
+
+  // Note: This is a simplified implementation. A more complete version would:
+  // 1. Update connection endpoints to match the new pin positions
+  // 2. Adjust line routing to account for the rotated passive
+  // 3. Handle position adjustments for the passive component
+}

--- a/lib/adapt/applyEditOperation/index.ts
+++ b/lib/adapt/applyEditOperation/index.ts
@@ -6,6 +6,7 @@ import { applyAddPassiveToPin } from "./applyAddPassiveToPin"
 import { applyRemoveChip } from "./applyRemoveChip"
 import { applyRemovePinFromSide } from "./applyRemovePinFromSide"
 import { applyAddPinToSide } from "./applyAddPinToSide"
+import { applyChangePassiveOrientation } from "./applyChangePassiveOrientation"
 
 /**
  * Mutates the circuit builder, applying the edit operation
@@ -29,6 +30,9 @@ export function applyEditOperation(C: CircuitBuilder, op: EditOperation): void {
       break
     case "remove_chip":
       applyRemoveChip(C, op)
+      break
+    case "change_passive_orientation":
+      applyChangePassiveOrientation(C, op)
       break
   }
 }

--- a/lib/adapt/detectPassiveOrientation.ts
+++ b/lib/adapt/detectPassiveOrientation.ts
@@ -1,0 +1,87 @@
+import type { ChipBuilder } from "lib/builder"
+import type { InputNetlist } from "lib/input-types"
+
+export type PassiveOrientation = "horizontal" | "vertical"
+
+/**
+ * Detects the orientation of a passive component based on its pin configuration
+ */
+export function detectPassiveOrientation(
+  chip: ChipBuilder,
+): PassiveOrientation {
+  if (!chip.isPassive) {
+    throw new Error(`Chip ${chip.chipId} is not a passive component`)
+  }
+
+  if (chip.leftPinCount > 0 || chip.rightPinCount > 0) {
+    return "horizontal"
+  } else {
+    return "vertical"
+  }
+}
+
+/**
+ * Detects the expected orientation of a passive component from the target netlist
+ * by analyzing the connection patterns
+ */
+export function detectExpectedPassiveOrientation(
+  netlist: InputNetlist,
+  passiveBoxId: string,
+): PassiveOrientation {
+  const passiveBox = netlist.boxes.find((box) => box.boxId === passiveBoxId)
+  if (!passiveBox) {
+    throw new Error(`Passive box ${passiveBoxId} not found in netlist`)
+  }
+
+  // Check if the passive has left/right pins (horizontal) or top/bottom pins (vertical)
+  if (passiveBox.leftPinCount > 0 || passiveBox.rightPinCount > 0) {
+    return "horizontal"
+  } else {
+    return "vertical"
+  }
+}
+
+/**
+ * Determines if a passive component needs orientation change to match the target
+ */
+export function needsOrientationChange(
+  currentChip: ChipBuilder,
+  targetNetlist: InputNetlist,
+): {
+  needsChange: boolean
+  operation?: {
+    type: "change_passive_orientation"
+    chipId: string
+    fromOrientation: PassiveOrientation
+    toOrientation: PassiveOrientation
+  }
+} {
+  if (!currentChip.isPassive) {
+    return { needsChange: false }
+  }
+
+  try {
+    const currentOrientation = detectPassiveOrientation(currentChip)
+    const expectedOrientation = detectExpectedPassiveOrientation(
+      targetNetlist,
+      currentChip.chipId,
+    )
+
+    if (currentOrientation !== expectedOrientation) {
+      return {
+        needsChange: true,
+        operation: {
+          type: "change_passive_orientation",
+          chipId: currentChip.chipId,
+          fromOrientation: currentOrientation,
+          toOrientation: expectedOrientation,
+        },
+      }
+    }
+  } catch (error) {
+    // If we can't detect orientation (e.g., passive not in target), don't change
+    return { needsChange: false }
+  }
+
+  return { needsChange: false }
+}

--- a/lib/adapt/transformTargetForPassiveCompatibility.ts
+++ b/lib/adapt/transformTargetForPassiveCompatibility.ts
@@ -1,0 +1,63 @@
+import type { CircuitBuilder } from "lib/builder"
+import type { InputNetlist } from "lib/input-types"
+import { detectPassiveOrientation } from "./detectPassiveOrientation"
+
+/**
+ * Transforms the target netlist to be compatible with the template's passive structures.
+ * Instead of changing the template's passives, we adapt the target to match the template.
+ */
+export function transformTargetForPassiveCompatibility(
+  template: CircuitBuilder,
+  target: InputNetlist,
+): InputNetlist {
+  // Create a copy of the target netlist to avoid mutating the original
+  const transformedTarget: InputNetlist = {
+    boxes: target.boxes.map((box) => ({ ...box })),
+    connections: target.connections.map((conn) => ({
+      ...conn,
+      connectedPorts: [...conn.connectedPorts],
+    })),
+  }
+
+  // Find passive components in both template and target
+  const templatePassives = template.chips.filter((chip) => chip.isPassive)
+
+  for (const templatePassive of templatePassives) {
+    const targetBox = transformedTarget.boxes.find(
+      (box) => box.boxId === templatePassive.chipId,
+    )
+    if (!targetBox) continue // Skip if passive doesn't exist in target
+
+    try {
+      const templateOrientation = detectPassiveOrientation(templatePassive)
+
+      // Transform the target passive's pin structure to match the template
+      if (templateOrientation === "vertical") {
+        // Template has vertical passive, ensure target matches
+        if (targetBox.leftPinCount > 0 || targetBox.rightPinCount > 0) {
+          // Target has horizontal structure, transform to vertical
+          const totalPins = targetBox.leftPinCount + targetBox.rightPinCount
+          targetBox.leftPinCount = 0
+          targetBox.rightPinCount = 0
+          targetBox.bottomPinCount = Math.ceil(totalPins / 2)
+          targetBox.topPinCount = Math.floor(totalPins / 2)
+        }
+      } else {
+        // Template has horizontal passive, ensure target matches
+        if (targetBox.bottomPinCount > 0 || targetBox.topPinCount > 0) {
+          // Target has vertical structure, transform to horizontal
+          const totalPins = targetBox.bottomPinCount + targetBox.topPinCount
+          targetBox.bottomPinCount = 0
+          targetBox.topPinCount = 0
+          targetBox.leftPinCount = Math.ceil(totalPins / 2)
+          targetBox.rightPinCount = Math.floor(totalPins / 2)
+        }
+      }
+    } catch (error) {
+      // If we can't detect orientation, skip transformation
+      continue
+    }
+  }
+
+  return transformedTarget
+}

--- a/tests/adapt/applyEditOperation/applyEditOperation13-change-passive-orientation.test.ts
+++ b/tests/adapt/applyEditOperation/applyEditOperation13-change-passive-orientation.test.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "bun:test"
+import { CircuitBuilder } from "lib/builder"
+import { applyEditOperation } from "lib/adapt/applyEditOperation"
+
+test("change passive orientation from vertical to horizontal", () => {
+  const C = new CircuitBuilder()
+  const U = C.chip().leftpins(1)
+
+  // Create a vertical passive (entry from bottom, exit to top)
+  U.pin(1).line(-2, 0).line(0, -2).passive().line(0, -2)
+
+  expect(C.chips.length).toBe(2) // U + passive
+
+  // Find the passive component
+  const passive = C.chips.find((chip) => chip.isPassive)
+  expect(passive).toBeDefined()
+  expect(passive!.chipId).toMatch(/^R\d+$/)
+
+  // Verify it's vertical (has bottom/top pins)
+  expect(passive!.bottomPinCount).toBe(1)
+  expect(passive!.topPinCount).toBe(1)
+  expect(passive!.leftPinCount).toBe(0)
+  expect(passive!.rightPinCount).toBe(0)
+
+  expect(`\n${C.toString()}\n`).toMatchInlineSnapshot(`
+    "
+       U1
+      ┌───┐
+    ├─┤1  │
+    │ └───┘
+    R2
+    │
+    │
+    "
+  `)
+
+  // Apply the orientation change
+  applyEditOperation(C, {
+    type: "change_passive_orientation",
+    chipId: passive!.chipId,
+    fromOrientation: "vertical",
+    toOrientation: "horizontal",
+  })
+
+  // Verify the passive is now horizontal (has left/right pins)
+  expect(passive!.leftPinCount).toBe(1)
+  expect(passive!.rightPinCount).toBe(1)
+  expect(passive!.bottomPinCount).toBe(0)
+  expect(passive!.topPinCount).toBe(0)
+
+  // Note: The visual representation may not change immediately as pin positions
+  // and connections would need to be recalculated
+  expect(`\n${C.toString()}\n`).toMatchInlineSnapshot(`
+    "
+       U1
+      ┌───┐
+    ├─┤1  │
+    │ └───┘
+    R2
+    │
+    │
+    "
+  `)
+})
+
+test("change passive orientation from horizontal to vertical", () => {
+  const C = new CircuitBuilder()
+  const U = C.chip().leftpins(1)
+
+  // Create a horizontal passive (entry from left, exit to right)
+  U.pin(1).line(-2, 0).passive().line(-2, 0)
+
+  expect(C.chips.length).toBe(2) // U + passive
+
+  // Find the passive component
+  const passive = C.chips.find((chip) => chip.isPassive)
+  expect(passive).toBeDefined()
+
+  // Verify it's horizontal (has left/right pins)
+  expect(passive!.leftPinCount).toBe(1)
+  expect(passive!.rightPinCount).toBe(1)
+  expect(passive!.bottomPinCount).toBe(0)
+  expect(passive!.topPinCount).toBe(0)
+
+  // Apply the orientation change
+  applyEditOperation(C, {
+    type: "change_passive_orientation",
+    chipId: passive!.chipId,
+    fromOrientation: "horizontal",
+    toOrientation: "vertical",
+  })
+
+  // Verify the passive is now vertical (has bottom/top pins)
+  expect(passive!.bottomPinCount).toBe(1)
+  expect(passive!.topPinCount).toBe(1)
+  expect(passive!.leftPinCount).toBe(0)
+  expect(passive!.rightPinCount).toBe(0)
+})

--- a/tests/e2e/e2e1.test.ts
+++ b/tests/e2e/e2e1.test.ts
@@ -63,12 +63,13 @@ test("SchematicLayoutPipelineSolver can process a CircuitBuilder netlist", () =>
     `\n${solver.adaptPhaseSolver?.outputAdaptedTemplates[0]?.template.toString()}\n`,
   ).toMatchInlineSnapshot(`
     "
-               U1
-              ┌───┐
-      ────────┤1 4├───D
-      │    ┌──┤2 3├───C
-    E─R2   │  └───┘
-      A    B
+             U1
+            ┌───┐
+    ├───────┤1 4├───D
+    │    ┌──┤2 3├───C
+    R2   │  └───┘
+    │    B
+    A
     "
   `)
 
@@ -79,18 +80,18 @@ test("SchematicLayoutPipelineSolver can process a CircuitBuilder netlist", () =>
 
 
                       ┌────────────────┐
-                     1│       U1       │4  ── D         
+            R2.2 ──  1│       U1       │4  ── D         
                B ──  2│                │3  ── C         
                       └────────────────┘
 
 
-                                       
+                             U1.1      
                               │        
-                              3        
-                      ┌────────────────┐
-               E ──  1│       R2       │                
-                      └────────────────┘
                               2        
+                      ┌────────────────┐
+                      │       R2       │                
+                      └────────────────┘
+                              1        
                               │        
                               A        
 
@@ -100,36 +101,17 @@ test("SchematicLayoutPipelineSolver can process a CircuitBuilder netlist", () =>
 
   expect(
     solver.adaptPhaseSolver?.outputAdaptedTemplates[0]?.appliedOperations,
+  ).toMatchInlineSnapshot(`[]`)
+
+  expect(
+    solver.adaptPhaseSolver?.outputAdaptedTemplates[0]?.template.toString(),
   ).toMatchInlineSnapshot(`
-    [
-      {
-        "betweenPinNumbers": [
-          0,
-          1,
-        ],
-        "chipId": "R2",
-        "side": "left",
-        "type": "add_pin_to_side",
-      },
-      {
-        "betweenPinNumbers": [
-          2,
-          3,
-        ],
-        "chipId": "R2",
-        "side": "right",
-        "type": "add_pin_to_side",
-      },
-      {
-        "chipId": "R2",
-        "pinNumber": 1,
-        "type": "add_label_to_pin",
-      },
-      {
-        "chipId": "R2",
-        "pinNumber": 3,
-        "type": "clear_pin",
-      },
-    ]
+    "         U1
+            ┌───┐
+    ├───────┤1 4├───D
+    │    ┌──┤2 3├───C
+    R2   │  └───┘
+    │    B
+    A"
   `)
 })


### PR DESCRIPTION
- **start big refactor**
- **wip first attempt**
- **add indexFromTop and indexFromLeft**
- **minor type fixes**
- **more progress on rewrite**
- **fix passive spacing**
- **fix pin1 pin2 swap issue**
- **grid edge fixes**
- **manually copy code for template**
- **update chipbuilder**
- **minor naming improvement**
- **improve test**
- **improve pin number drawing**
- **deprecate leftside etc.**
- **format and change chip id for passive**
- **mini factor**
- **import fix**
- **wip**
- **wip**
- **wip**
- **fix template1**
- **refactor progress**
- **allow two pin non-passives**
- **wip repro issue with get compatible netlists**
- **add intersect test**
- **handling for intersections and connection points**
- **update template snapshots**
- **fix flip, work on netlist compat tests**
- **fix test**
- **minor snapshot updates**
- **fix clone**
- **clear content of mergeCircuits**
- **wip merge circuits migration**
- **fix merge circuits**
- **minor type fixes**
- **setup for creating template variations**
- **fix finding half boxes, template variations**
- **reproduce circuit flipping issue**
- **fix mergeCircuits**
- **snapshot circuit json to start autolayout for circuit json**
- **netlist stuff**
- **add circuit json conversion to netlists**
- **setup for tscircuit test for applying layout**
- **wip apply circuit layout**
- **wip**
- **init apply layout**
- **add initial svg testing**
- **snapshot tscircuit**
- **test should show the layout we're applying**
- **normalization mechanism to number graph nodes**
- **logging for schematic port positions**
- **fix infinite loop in getSidePinIndex test**
- **progress on applying layout, pin location fixes**
- **wip getting closer to applying layout**
- **move schematic labels**
- **better net ids to properly separate schematic net labels**
- **wip**
- **wip**
- **move aawy from moving existing labels, instead creating new ones**
- **recreate net labels instead of moving them**
- **defaultChipWidth concept**
- **allow floating point lines and pin points for grid visual**
- **new example, working on application**
- **remove bifurcate, add schpinspacing**
- **introduce schematic pin spacing**
- **debugging netlist normalization**
- **fix some lint issues with normalize netlist**
- **log iterMap, set up tscircuit1 to debug iterMap**
- **wip, refactor to "encounter map"**
- **add netIds to encounter map**
- **normalize netId ordering by encounter map**
- **redundant net labels working**
- **getNetlistAsReadableTree method**
- **bootstrap apply edit operation**
- **wip apply operation**
- **add label to pin edit operation**
- **more adapt bootstrapping**
- **progress towards getPinSubsetNetlist**
- **add ther pins**
- **progress towards adapting template**
- **quick implementations of apply edit operation methods**
- **break up tests**
- **fix apply edit operation**
- **fix test output**
- **fix add pins to side logic**
- **confirm pin removal working**
- **placeholder for add/remove pin from side**
- **wip applying edit operations**
- **wip edit operation add pin to side test**
- **revert slop related to adding pins to side**
- **add remove pin test**
- **fix add pin to side**
- **wip remove pin and compute edit operations to fix pin subset netlist**
- **init compute edit operations to fix pin subset netlist**
- **format**
- **more compute edit operation tests**
- **snapshot for passive add**
- **add correct answer**
- **add support for add passive to pin for subset netlist fixes**
- **add initial adapt template to target test**
- **add correct snapshot**
- **wip remove operations that add multiple pins to a side**
- **handle edge case for inserting at first pin**
- **add multi required operations to test**
- **add test confirming add pin on right side works**
- **fix right side modification on template**
- **init test for remove/add labels**
- **adapt with adding and removing labels**
- **lots of setup for box matching and scoring**
- **first getMatchedBoxes test**
- **fix matching with basic side count matching**
- **match box test 3, setup for chip labels**
- **add chip label support**
- **improve snapshot**
- **update snapshots to have label**
- **alphabetical labels and draw full passive labels**
- **fix passive pin1/pin2 configuration for upward direction**
- **update templates for passive dir**
- **update snapshots to new stringify method**
- **Update README.md**
- **Update README.md**
- **update template comments, start readme usage**
- **setup for pipeline solver**
- **setup for solver/iteration pattern**
- **wip todo for single match solver**
- **wip refactor for findBestMatch**
- **building up pipeline, finished singlematchsolver**
- **wip e2e test with specific testing for matching**
- **e2e matching working properly**
- **add claude md**
- **format, integrate adapt phase solver**
- **format**
- **format**
- **repro additional chip issue**
- **implement add label to pin edit operation**
- **add remove chip adaptation**
- **more details added to matching test**
- **wip comparing pin shape signatures**
- **add support for matched_box_missing_pin_shape**
- **more debugging and progress towards improving matching**
- **add test confirming behavior of getPinSubsetNetlist for intersects()**
- **major fix to intersects math (intersects weren't altering netlist)**
- **demonstration bad adaptation in e2e1**
- **find pin shapes in wrong position**
- **update test for better visual**
- **update test snapshot for new passive positions**
- **add remove pin operation**
- **update remove pin test**
- **remove matching2 reversal, not related until later**
- **adaptation example failure where we don't add a passive**
- **more edit operation fixes**
- **remove "unmatched" chips as a first step when adapting**
- **update test snapshots**
- **when adapting, transform input passives to consistent orientation**
